### PR TITLE
Add control, telemetry, accelerometer and gyroscope handlers

### DIFF
--- a/muse-lsl.py
+++ b/muse-lsl.py
@@ -37,7 +37,7 @@ def process(data, timestamps):
     for ii in range(12):
         outlet.push_sample(data[:, ii], timestamps[ii])
 
-muse = Muse(address=options.address, callback=process,
+muse = Muse(address=options.address, callback_eeg=process,
             backend=options.backend, time_func=local_clock,
             interface=options.interface, name=options.name)
 

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -112,10 +112,35 @@ class Muse():
     def ask_control(self):
         """Send a message to Muse to ask for the control status.
 
-        The device will answer with battery status, device name, preset selected, and other control information.
+        Only useful if control is enabled (to receive the answer!)
 
-        Only useful if control is enabled (to receive the answer!)"""
+        The message received is a dict with the following keys:
+        "hn": device name
+        "sn": serial number
+        "ma": MAC address
+        "id":
+        "bp": battery percentage
+        "ts":
+        "ps": preset selected
+        "rc": return status, if 0 is OK
+        """
         self._write_cmd([0x02, 0x73, 0x0a])
+
+    def ask_device_info(self):
+        """Send a message to Muse to ask for the device info.
+
+        The message received is a dict with the following keys:
+        "ap":
+        "sp":
+        "tp": firmware type, e.g: "consumer"
+        "hw": hardware version?
+        "bn": build number?
+        "fw": firmware version?
+        "bl":
+        "pv": protocol version?
+        "rc": return status, if 0 is OK
+        """
+        self._write_cmd([0x03, 0x76, 0x31, 0x0a])
 
     def start(self):
         """Start streaming."""

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -107,6 +107,12 @@ class Muse():
         cmd -- list of bytes"""
         self.device.char_write_handle(0x000e, cmd, False)
 
+    def ask_control(self):
+        """Send a message to Muse to ask for the control.
+
+        Only useful if control is enabled (to receive the answer!)"""
+        self._write_cmd([0x02, 0x73, 0x0a])
+
     def start(self):
         """Start streaming."""
         self._init_timestamp_correction()

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -108,7 +108,9 @@ class Muse():
         self.device.char_write_handle(0x000e, cmd, False)
 
     def ask_control(self):
-        """Send a message to Muse to ask for the control.
+        """Send a message to Muse to ask for the control status.
+
+        The device will answer with battery status, device name, preset selected, and other control information.
 
         Only useful if control is enabled (to receive the answer!)"""
         self._write_cmd([0x02, 0x73, 0x0a])

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -101,18 +101,24 @@ class Muse():
 
         return None
 
+    def _write_cmd(self, cmd):
+        """Wrapper to write a command to the Muse device.
+
+        cmd -- list of bytes"""
+        self.device.char_write_handle(0x000e, cmd, False)
+
     def start(self):
         """Start streaming."""
         self._init_timestamp_correction()
         self._init_sample()
         self.last_tm = 0
-        self.device.char_write_handle(0x000e, [0x02, 0x64, 0x0a], False)
+        self._write_cmd([0x02, 0x64, 0x0a])
 
         self._init_control()
 
     def stop(self):
         """Stop streaming."""
-        self.device.char_write_handle(0x000e, [0x02, 0x68, 0x0a], False)
+        self._write_cmd([0x02, 0x68, 0x0a])
 
     def disconnect(self):
         """disconnect."""


### PR DESCRIPTION
I added handlers for control (that are responses from the muse to sent commands), telemetry (battery, temperature and stuff), accelerometer and gyroscope messages from the device.
Some comments: 
- I used some constants that @urish used in https://github.com/urish/muse-js, to get the correct units I presume (all the credits to him!)
- In the constructor of the `Muse` class I think that the `eeg`, `control`, `telemetry`, `accelero` and `giro` parameters should be deprecated, and instead subscribe to each channel when a callback is provided. Also the callback for eeg could be called `callback_eeg`. This changes are not backward-compatible so I didn't do them, but I can do them if you want :smile: 

Also, I did a minor refactor when writing commands to muse, only one method in the Muse class handles the writing to the device.

UPDATE: I added a method in the Muse class to send a command to the device asking for control information. The device will return data like battery status, device name, preset selected, and more.