### PR TITLE
Adding ACC and GYRO as additional LSL outlets

### DIFF
--- a/muse-lsl.py
+++ b/muse-lsl.py
@@ -81,7 +81,7 @@ process_acc = partial(process, outlet=outlet_acc)
 process_gyro = partial(process, outlet=outlet_gyro)
 
 muse = Muse(address=options.address, callback_eeg=process_eeg,
-            callback_control=print, callback_telemetry=print,
+            callback_control=None, callback_telemetry=None,
             callback_acc=process_acc, callback_gyro=process_gyro,
             backend=options.backend, interface=options.interface,
             name=options.name)

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -124,7 +124,6 @@ class Muse():
         "ps": preset selected
         "rc": return status, if 0 is OK
         """
-
         self._write_cmd([0x02, 0x73, 0x0a])
 
     def ask_device_info(self):

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -124,6 +124,7 @@ class Muse():
         "ps": preset selected
         "rc": return status, if 0 is OK
         """
+
         self._write_cmd([0x02, 0x73, 0x0a])
 
     def ask_device_info(self):

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -151,8 +151,6 @@ class Muse():
 
         self._init_control()
 
-        self._init_control()
-
     def stop(self):
         """Stop streaming."""
         self._write_cmd([0x02, 0x68, 0x0a])
@@ -161,7 +159,6 @@ class Muse():
         """disconnect."""
         self.device.disconnect()
         self.adapter.stop()
-
 
     def _subscribe_eeg(self):
         """subscribe to eeg stream."""

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -151,6 +151,8 @@ class Muse():
 
         self._init_control()
 
+        self._init_control()
+
     def stop(self):
         """Stop streaming."""
         self._write_cmd([0x02, 0x68, 0x0a])


### PR DESCRIPTION
This PR builds on #32 and adds the ACC and GYRO streams as LSL outlets, and also adds support for these two data streams in `lsl-viewer.py`.