### PR TITLE
Correcting connection issue

### DIFF
--- a/muse/muse.py
+++ b/muse/muse.py
@@ -148,10 +148,12 @@ class Muse():
         self._init_sample()
         self.last_tm = 0
         # setting preset 20 : http://developer.choosemuse.com/hardware-firmware/headband-configuration-presets
-        self._write_cmd([0x04, 0x70, 0x32, 0x30, 0x0a]) # 0x733230 = 'p20' for preset 20
-        self._write_cmd([0x02, 0x73, 0x0a]) # 0x73 = 's' for start
-        self._write_cmd([0x02, 0x64, 0x0a]) # 0x64 = 'd' for resume (??)
-
+        self._write_cmd([0x03, 0x76, 0x31, 0x0a]) # 'v1' snooped from Muse App
+        self._write_cmd([0x02, 0x73, 0x0a]) # 's', snooped from Muse App
+        self._write_cmd([0x02, 0x68, 0x0a]) # 'h', snooped from Muse App
+        self._write_cmd([0x04, 0x70, 0x32, 0x31, 0x0a]) # 'p21' for preset 21
+        self._write_cmd([0x02, 0x73, 0x0a]) # 's' for start
+        self._write_cmd([0x02, 0x64, 0x0a]) # 'd' for resume (??)
         self._init_control()
 
     def resume(self):

--- a/muse/muse.py
+++ b/muse/muse.py
@@ -147,13 +147,24 @@ class Muse():
         self._init_timestamp_correction()
         self._init_sample()
         self.last_tm = 0
-        self._write_cmd([0x02, 0x64, 0x0a])
+        # setting preset 20 : http://developer.choosemuse.com/hardware-firmware/headband-configuration-presets
+        self._write_cmd([0x04, 0x70, 0x32, 0x30, 0x0a]) # 0x733230 = 'p20' for preset 20
+        self._write_cmd([0x02, 0x73, 0x0a]) # 0x73 = 's' for start
+        self._write_cmd([0x02, 0x64, 0x0a]) # 0x64 = 'd' for resume (??)
 
         self._init_control()
 
+    def resume(self):
+        """Resume streaming."""
+        self._write_cmd([0x02, 0x64, 0x0a])
+        
     def stop(self):
         """Stop streaming."""
         self._write_cmd([0x02, 0x68, 0x0a])
+
+    def keep_alive(self):
+        """Keep streaming."""
+        self._write_cmd([0x02, 0x6b, 0x0a])
 
     def disconnect(self):
         """disconnect."""


### PR DESCRIPTION
I found that my Muse headband could not connect directly after a night charging up. I should start the Muse app on my phone, connect the band and then I could use muse-lsl. This happens each time that I fully charge my headband with a phone charger. I did some tests with different chargers and in different places, this does not happen in certain configurations, but I could not get the bottom of it. Nonetheless, it systematically happens in the building where I need the headband, hence this PR.

I activated the developer mode on my android Phone to "Enable Bluetooth HCI snoop log" and I analyzed the exchanges with Wireshark between the Muse phone app and the headband (when it could not connect). I found out that the Muse app sends an `ask_device_info` sequence (`0x03 76 31 0a`) and that, in its response, the 'ap' field of the headband is set to 'bootloader' (instead of 'headset' in a functional headband). When the headband is in 'bootloader' mode, the Muse app sends a special sequence that I identified as a "reset to headset mode" order (`0x03 2a 31 0a`, or `*1` in ASCII). The headband then reboots, cutting the Bluetooth connection. Once reconnected, the `ask_device_info` returns now the correct 'headset' value in the 'ap' field.

I also spotted that, after "resetting", the headband preset mode is indicated as "32" which seems to map to preset 20 from the [official documentation](http://developer.choosemuse.com/hardware-firmware/headband-configuration-presets). The Muse app then change the preset to 21, with the sequence `0x04 70 32 31 0a, which is also [documented here](https://articles.jaredcamins.com/figuring-out-bluetooth-low-energy-part-2-750565329a7d).

I proposed the following update in this PR:
- adding the function `select_preset` to set the preset to indicated value (default is 21)
- adding a 'keep alive' function, [documented here](https://articles.jaredcamins.com/figuring-out-bluetooth-low-energy-part-2-750565329a7d). It is not used in this PR, but it could be useful later.
- the main change is in the `connect` function: I send a reset order, wait for 2 sec, reconnect, then change the preset. The 2 second delay could be shortened, it is 5 second on the Muse app. Compared to the main branch, and assuming a headband already working well with muse-lsl, this adds a small inconvenience as the muse-lsl take 2 more seconds before starting to stream. But then again, it could be cut to half a second or less without taking any risk. The fact that the Muse headband is reset at each connection does not seem to have any effect.
- before opening this PR, I made a PEP8 check and corrected most of it. Unfortunately, this made the changes in the PR less visible. Sorry for that, won't make the same mistake next time.

Instead of making a reset at each connection, a better approach could be to use an internal callback responding to `ask_device_info` and to triggers the reset depending on the 'ap' field value. Unfortunately, with the concurrent programming, I did not find a correct way to do that.