### PR TITLE
Adapter handling to fix issues with list_muses on Mac

### DIFF
--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -22,8 +22,10 @@ def list_muses(backend='auto', interface=None):
     else:
         adapter = pygatt.BGAPIBackend(serial_port=interface)
 
+    adapter.start()
     print('Searching for Muses, this may take up to 10 seconds...')
     devices = adapter.scan(timeout=MUSE_SCAN_TIMEOUT)
+    adapter.stop()
     muses = []
 
     for device in devices:


### PR DESCRIPTION
It looks like calling adapter.scan is a special requirement when using the BGAPI backend that we didn't account for: https://github.com/peplin/pygatt/blob/b2777f3b781a71e3a7611b88d9a87f8b4c177466/pygatt/backends/bgapi/bgapi.py#L81

This fix introduces start and stop calls around the `adapter.scan` function in `list_muses`. Before we merge, we should check that this fixes https://github.com/alexandrebarachant/muse-lsl/issues/51 on Mac and doesn't change functionality on Linux. I've confirmed that Windows is unaffected