### PR TITLE
Bumped version of pygatt to 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='muselsl',
       package_data={'muselsl': ['docs/README.md', 'docs/examples/*']},
       include_package_data=True,
       zip_safe=False,
-      install_requires=['bitstring', 'pylsl', 'pygatt==3.1.1',
+      install_requires=['bitstring', 'pylsl', 'pygatt==3.2.0',
                         'pandas', 'scikit-learn', 'numpy', 'seaborn', 'pexpect'],
       extras_require={'Viewer V2': ['mne', 'vispy']},
       classifiers=[


### PR DESCRIPTION
I think increasing the version of pygatt should hopefully fix the bluegiga issues we've been running into on all platforms:

https://github.com/alexandrebarachant/muse-lsl/issues/68