### PR TITLE
Force Linux installations to use pylsl 1.10.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ Lab Streaming Layer or LSL is a system designed to unify the collection of time 
 4.  `pygatt.exceptions.BLEError: Unexpected error when scanning: Set scan parameters failed: Connection timed out` (Linux)
 
 - This seems to be due to a OS-level Bluetooth crash. Try turning your computer's bluetooth off and on again
+
+5.  `'RuntimeError: could not create stream outlet'` (Linux)
+
+- This appears to be due to Linux-specific issues with the newest version of pylsl. Ensure that you have pylsl 10.1.5 installed in the environment in which you are trying to run Muse LSL

--- a/setup.py
+++ b/setup.py
@@ -30,14 +30,14 @@ setup(
     zip_safe=False,
     install_requires=[
         "bitstring",
-        "pylsl",
         "pygatt",
         "pandas",
         "scikit-learn",
         "numpy",
         "seaborn",
         "pexpect",
-    ],
+    ]
+    + (["pylsl==1.10.5"] if os.sys.platform.startswith("linux") else ["pylsl"]),
     extras_require={"Viewer V2": ["mne", "vispy"]},
     classifiers=[
         # How mature is this project?  Common values are

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='muselsl',
       package_data={'muselsl': ['docs/README.md', 'docs/examples/*']},
       include_package_data=True,
       zip_safe=False,
-      install_requires=['bitstring', 'pylsl', 'pygatt==3.1.1',
+      install_requires=['bitstring', 'pylsl', 'pygatt==3.2.0',
                         'pandas', 'scikit-learn', 'numpy', 'seaborn', 'pexpect'],
       extras_require={'Viewer V2': ['mne', 'vispy']},
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ copy_docs()
 
 setup(
     name="muselsl",
-    version="1.0.4",
+    version="1.0.5",
     description="Stream and visualize EEG data from the Muse 2016 headset.",
     keywords="muse lsl eeg ble neuroscience",
     url="https://github.com/alexandrebarachant/muse-lsl/",


### PR DESCRIPTION
This updates the setup.py file to force 1.10.5 for linux installations in order to deal with stream outlet creation issues outlined in https://github.com/alexandrebarachant/muse-lsl/issues/72