### PR TITLE
Fix AUXR and PPG channels not streaming under bgapi

### DIFF
--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -44,11 +44,16 @@ class CLI:
                             default=False, action="store_true", help="Include gyroscope data")
         parser.add_argument('-d', '--disable-eeg', dest='disable_eeg',
                             action='store_true', help="Disable EEG data")
+        parser.add_argument("-P", "--preset", type=int,
+                            help="Select preset which dictates data channels to be streamed")
+
         args = parser.parse_args(sys.argv[2:])
         from . import stream
 
+        print("CLI Preset {}".format(args.preset))
+
         stream(args.address, args.backend,
-               args.interface, args.name, args.ppg, args.acc, args.gyro, args.disable_eeg)
+               args.interface, args.name, args.ppg, args.acc, args.gyro, args.disable_eeg, args.preset)
 
     def record(self):
         parser = argparse.ArgumentParser(

--- a/muselsl/muse.py
+++ b/muselsl/muse.py
@@ -13,7 +13,8 @@ class Muse():
 
     def __init__(self, address, callback_eeg=None, callback_control=None,
                  callback_telemetry=None, callback_acc=None, callback_gyro=None,
-                 callback_ppg=None, backend='auto', interface=None, time_func=time, name=None):
+                 callback_ppg=None, backend='auto', interface=None, time_func=time, name=None,
+                 preset=21):
         """Initialize
 
         callback_eeg -- callback for eeg data, function(data, timestamps)
@@ -41,6 +42,7 @@ class Muse():
         self.enable_acc = not callback_acc is None
         self.enable_gyro = not callback_gyro is None
         self.enable_ppg = not callback_ppg is None
+        self.preset = preset
 
         self.interface = interface
         self.time_func = time_func
@@ -193,6 +195,7 @@ class Muse():
         self.last_tm = 0
         self.last_tm_ppg = 0
         self._init_control()
+        self.select_preset(self.preset)
         self.resume()
 
     def resume(self):
@@ -223,14 +226,23 @@ class Muse():
         For 2016 headband, possible choice are 'p20' and 'p21'.
         Untested but possible values are 'p22' and 'p23'
         Default is 'p21'."""
+
+        print("Using preset {}".format(preset))
+
         if preset == 20:
             self._write_cmd([0x04, 0x70, 0x32, 0x30, 0x0a])
+        elif preset == 21:
+            self._write_cmd([0x04, 0x70, 0x32, 0x31, 0x0a])
         elif preset == 22:
             self._write_cmd([0x04, 0x70, 0x32, 0x32, 0x0a])
         elif preset == 23:
             self._write_cmd([0x04, 0x70, 0x32, 0x33, 0x0a])
+        elif preset == 50:
+            self._write_cmd([0x04, 0x70, 0x35, 0x30, 0x0a])
+        elif preset == 51:
+            self._write_cmd([0x04, 0x70, 0x35, 0x31, 0x0a])
         else:
-            self._write_cmd([0x04, 0x70, 0x32, 0x31, 0x0a])
+            raise Exception('Unknown preset %s', preset)
 
     def disconnect(self):
         """disconnect."""

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -59,7 +59,7 @@ def find_muse(name=None):
 
 
 # Begins LSL stream(s) from a Muse with a given address with data sources determined by arguments
-def stream(address, backend='auto', interface=None, name=None, ppg_enabled=False, acc_enabled=False, gyro_enabled=False, eeg_disabled=False,):
+def stream(address, backend='auto', interface=None, name=None, ppg_enabled=False, acc_enabled=False, gyro_enabled=False, eeg_disabled=False, preset=21):
     bluemuse = backend == 'bluemuse'
     if not bluemuse:
         if not address:
@@ -140,7 +140,7 @@ def stream(address, backend='auto', interface=None, name=None, ppg_enabled=False
         return
 
     muse = Muse(address=address, callback_eeg=push_eeg, callback_ppg=push_ppg, callback_acc=push_acc, callback_gyro=push_gyro,
-                backend=backend, interface=interface, name=name)
+                backend=backend, interface=interface, name=name, preset=preset)
 
     if(bluemuse):
         muse.connect()


### PR DESCRIPTION
It appears that muse (self.select_preset) was no longer being called when
the streaming started. This prevented the select preset command from being
sent to the headset, which means that it would never sample data on anything
except for the default channels.

At this time, it is not enough to subscribe to the GATT attributes of the
desired data, the correct preset number must also be sent in order to
instruct the headset which channels are to be sampled.

I have added a new command line argument '-P' '--preset', which allows an
integer to be passed for selecting the preset. For reference::

    20 - 5-Channel EEG channel streaming
    21 - 4-Channel EEG channel streaming
    22 - 4-Channel EEG channel streaming without accel/gyro

    50 - Same as 20, but includes PPG data
    51 - Same as 21, but includes PPG data

I have not yet tested this with a backend other than BGAPI, so I'm not
sure if Bluemuse will send the preset information either.