### PR TITLE
Configurable stream timeout

### DIFF
--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -59,7 +59,17 @@ def find_muse(name=None):
 
 
 # Begins LSL stream(s) from a Muse with a given address with data sources determined by arguments
-def stream(address, backend='auto', interface=None, name=None, ppg_enabled=False, acc_enabled=False, gyro_enabled=False, eeg_disabled=False,):
+def stream(
+    address,
+    backend='auto',
+    interface=None,
+    name=None,
+    ppg_enabled=False,
+    acc_enabled=False,
+    gyro_enabled=False,
+    eeg_disabled=False,
+    timeout=AUTO_DISCONNECT_DELAY,
+):
     # If no data types are enabled, we warn the user and return immediately.
     if eeg_disabled and not ppg_enabled and not acc_enabled and not gyro_enabled:
         print('Stream initiation failed: At least one data source must be enabled.')
@@ -157,7 +167,7 @@ def stream(address, backend='auto', interface=None, name=None, ppg_enabled=False
             print("Streaming%s%s%s%s..." %
                 (eeg_string, ppg_string, acc_string, gyro_string))
 
-            while time() - muse.last_timestamp < AUTO_DISCONNECT_DELAY:
+            while time() - muse.last_timestamp < timeout:
                 try:
                     sleep(1)
                 except KeyboardInterrupt:


### PR DESCRIPTION
Allow the user to configure the timeout on streams. Defaults to the current setting of `AUTO_DISCONNECT_DELAY`. We've found that increasing this value can improve stream stability in some cases.