### PR TITLE
Workaround for list_muses failing when backend='gatt' on linux

### DIFF
--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -1,9 +1,12 @@
-from time import time, sleep
-from pylsl import StreamInfo, StreamOutlet
-from functools import partial
-import pygatt
+import re
 import subprocess
 from sys import platform
+from time import time, sleep
+from functools import partial
+
+from pylsl import StreamInfo, StreamOutlet
+import pygatt
+
 from . import helper
 from .muse import Muse
 from .constants import MUSE_SCAN_TIMEOUT, AUTO_DISCONNECT_DELAY,  \
@@ -11,6 +14,13 @@ from .constants import MUSE_SCAN_TIMEOUT, AUTO_DISCONNECT_DELAY,  \
     MUSE_NB_PPG_CHANNELS, MUSE_SAMPLING_PPG_RATE, LSL_PPG_CHUNK, \
     MUSE_NB_ACC_CHANNELS, MUSE_SAMPLING_ACC_RATE, LSL_ACC_CHUNK, \
     MUSE_NB_GYRO_CHANNELS, MUSE_SAMPLING_GYRO_RATE, LSL_GYRO_CHUNK
+
+
+def _print_muse_list(muses):
+    for m in muses:
+        print(f'Found device {m["name"]}, MAC Address {m["address"]}')
+    if not muses:
+        print('No Muses found.')
 
 
 # Returns a list of available Muse devices.
@@ -27,22 +37,67 @@ def list_muses(backend='auto', interface=None):
     else:
         adapter = pygatt.BGAPIBackend(serial_port=interface)
 
-    adapter.start()
+    try:
+        adapter.start()
+        print('Searching for Muses, this may take up to 10 seconds...')
+        devices = adapter.scan(timeout=MUSE_SCAN_TIMEOUT)
+        adapter.stop()
+    except pygatt.exceptions.BLEError as e:
+        if backend == 'gatt':
+            print('pygatt failed to scan for BLE devices. Trying with '
+                  'bluetoothctl.')
+            return  _list_muses_bluetoothctl(MUSE_SCAN_TIMEOUT)
+        else:
+            raise e
+
+    muses = [d for d in devices if d['name'] and 'Muse' in d['name']]
+    _print_muse_list(muses)
+
+    return muses
+
+
+def _list_muses_bluetoothctl(timeout, verbose=False):
+    """Identify Muse BLE devices using bluetoothctl.
+
+    When using backend='gatt' on Linux, pygatt relies on the command line tool
+    `hcitool` to scan for BLE devices. `hcitool` is however deprecated, and
+    seems to fail on Bluetooth 5 devices. This function roughly replicates the
+    functionality of `pygatt.backends.gatttool.gatttool.GATTToolBackend.scan()`
+    using the more modern `bluetoothctl` tool.
+
+    Deprecation of hcitool: https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=b1eb2c4cd057624312e0412f6c4be000f7fc3617
+    """
+    try:
+        import pexpect
+    except (ImportError, ModuleNotFoundError):
+        msg = ('pexpect is currently required to use bluetoothctl from within '
+               'a jupter notebook environment.')
+        raise ModuleNotFoundError(msg)
+
+    # Run scan using pexpect as subprocess.run returns immediately in jupyter
+    # notebooks
     print('Searching for Muses, this may take up to 10 seconds...')
-    devices = adapter.scan(timeout=MUSE_SCAN_TIMEOUT)
-    adapter.stop()
-    muses = []
+    scan = pexpect.spawn('bluetoothctl scan on')
+    try:
+        scan.expect('foooooo', timeout=timeout)
+    except pexpect.EOF:
+        before_eof = scan.before.decode('utf-8', 'replace')
+        msg = f'Unexpected error when scanning: {before_eof}'
+        raise ValueError(msg)
+    except pexpect.TIMEOUT:
+        if verbose:
+            print(scan.before.decode('utf-8', 'replace').split('\r\n'))
 
-    for device in devices:
-        if device['name'] and 'Muse' in device['name']:
-            muses = muses + [device]
-
-    if(muses):
-        for muse in muses:
-            print('Found device %s, MAC Address %s' %
-                  (muse['name'], muse['address']))
-    else:
-        print('No Muses found.')
+    # List devices using bluetoothctl
+    list_devices_cmd = ['bluetoothctl', 'devices']
+    devices = subprocess.run(
+        list_devices_cmd, stdout=subprocess.PIPE).stdout.decode(
+            'utf-8').split('\n')
+    muses = [{
+            'name': re.findall('Muse.*', string=d)[0],
+            'address': re.findall(r'..:..:..:..:..:..', string=d)[0]
+        } for d in devices if 'Muse' in d]
+    _print_muse_list(muses)
 
     return muses
 


### PR DESCRIPTION
This PR introduces a workaround to use `list_muses` with gatt on Linux.

Some context: When using backend='gatt' on Linux, pygatt relies on the command line tool `hcitool` to scan for BLE devices. `hcitool` is however deprecated, and seems to fail on Bluetooth 5 devices. This workaround roughly replicates the functionality of [`pygatt.backends.gatttool.gatttool.GATTToolBackend.scan()`](https://github.com/peplin/pygatt/blob/master/pygatt/backends/gatttool/gatttool.py#L322) using the more modern `bluetoothctl` tool.

I had to rely on pexpect to run `bluetoothctl scan on` as `subprocess.run` seems to be returning before any device can be found when used in a jupyter notebook environment, which doesn't make for a very elegant approach. Also, I suppose this might be of interest to the pygatt folks, but wanted to make a quick fix available for the `eeg-notebooks` sprint at BrainHack Ontario.

Deprecation of hcitool: https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=b1eb2c4cd057624312e0412f6c4be000f7fc3617

@m9h @JohnGriffiths