### PR TITLE
ci: added basic CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: Test
+
+on:
+  push:
+    branches: [ master, 'dev/*' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: ${{ matrix.os }}, py-${{ matrix.python_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macOS-latest]
+        python_version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python_version }}
+    - name: Install Linux dependencies
+      if: "startsWith(runner.os, 'Linux')"
+      run: |
+        python -m pip install --upgrade pip wheel
+
+        # Install wxPython wheels since they are distribution-specific and therefore not on PyPI
+        # See: https://wxpython.org/pages/downloads/index.html
+        pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
+
+        pip install .
+    - name: Install MacOS/Windows dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install .
+
+  typecheck:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python_version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python_version }}
+    - name: Install dependencies
+      run: |
+        pip install .
+        pip install mypy
+    - name: Typecheck
+      run: |
+        python -m mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,8 @@
 # bdist_wheel from trying to make a universal wheel. For more see:
 # https://packaging.python.org/tutorials/distributing-packages/#wheels
 universal=1
+
+[mypy]
+files = muselsl/**/*.py
+ignore_missing_imports = true
+check_untyped_defs = true


### PR DESCRIPTION
See example of passing run here: https://github.com/ErikBjare/muse-lsl/actions/runs/545096295

Doesn't run any tests or anything (at the moment), but at least makes sure it's installable on all platforms, and runs basic typechecking with `mypy`.

It is my hope that this will help with merging PRs faster.