### PR TITLE
Add a command line switch to disable the light on Muse S

### DIFF
--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -92,13 +92,19 @@ class CLI:
             dest='disable_eeg',
             action='store_true',
             help="Disable EEG data")
+        parser.add_argument(
+            '-dl',
+            '--disable-light',
+            dest='disable_light',
+            action='store_true',
+            help='Turn off headband light')
 
 
         args = parser.parse_args(sys.argv[2:])
         from . import stream
 
         stream(args.address, args.backend, args.interface, args.name, args.ppg,
-               args.acc, args.gyro, args.disable_eeg, args.preset)
+               args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light)
 
     def record(self):
         parser = argparse.ArgumentParser(

--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -97,7 +97,7 @@ class CLI:
             '--disable-light',
             dest='disable_light',
             action='store_true',
-            help='Turn off headband light')
+            help='Turn off light on the Muse S headband')
 
 
         args = parser.parse_args(sys.argv[2:])

--- a/muselsl/muse.py
+++ b/muselsl/muse.py
@@ -23,7 +23,8 @@ class Muse():
                  interface=None,
                  time_func=time,
                  name=None,
-                 preset=None):
+                 preset=None,
+                 disable_light=False):
         """Initialize
 
         callback_eeg -- callback for eeg data, function(data, timestamps)
@@ -56,6 +57,7 @@ class Muse():
         self.time_func = time_func
         self.backend = helper.resolve_backend(backend)
         self.preset = preset
+        self.disable_light = disable_light
 
     def connect(self, interface=None, backend='auto'):
         """Connect to the device"""
@@ -98,6 +100,9 @@ class Muse():
 
                 if self.enable_ppg:
                     self._subscribe_ppg()
+                
+                if self.disable_light:
+                    self._disable_light()
 
                 self.last_timestamp = self.time_func()
 
@@ -128,6 +133,9 @@ class Muse():
 
                 if self.enable_ppg:
                     self._subscribe_ppg()
+                
+                if self.disable_light:
+                    self._disable_light()
 
                 self.last_timestamp = self.time_func()
 
@@ -587,3 +595,6 @@ class Muse():
         data = res[1:]
 
         return packetIndex, data
+    
+    def _disable_light(self):
+        self._write_cmd_str('L0')

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -129,6 +129,7 @@ def stream(
     gyro_enabled=False,
     eeg_disabled=False,
     preset=None,
+    disable_light=False,
     timeout=AUTO_DISCONNECT_DELAY,
 ):
     # If no data types are enabled, we warn the user and return immediately.
@@ -212,7 +213,7 @@ def stream(
         push_gyro = partial(push, outlet=gyro_outlet) if gyro_enabled else None
 
         muse = Muse(address=address, callback_eeg=push_eeg, callback_ppg=push_ppg, callback_acc=push_acc, callback_gyro=push_gyro,
-                    backend=backend, interface=interface, name=name, preset=preset)
+                    backend=backend, interface=interface, name=name, preset=preset, disable_light=disable_light)
 
         didConnect = muse.connect()
 


### PR DESCRIPTION
This way you can monitor sleep without a disturbing orange light on your forehead.