### PR TITLE
Patch: Update bleak Scanner logic to match example

### DIFF
--- a/muselsl/backends.py
+++ b/muselsl/backends.py
@@ -30,8 +30,7 @@ class BleakBackend:
     def scan(self, timeout=10):
         if isinstance(bleak, ModuleNotFoundError):
             raise bleak
-        scanner = bleak.BleakScanner()
-        devices = _wait(scanner.discover(timeout))
+        devices = _wait(bleak.BleakScanner.discover(timeout))
         return [{'name':device.name, 'address':device.address} for device in devices]
     def connect(self, address):
         result = BleakDevice(self, address)


### PR DESCRIPTION
When investigating this issue (https://github.com/alexandrebarachant/muse-lsl/issues/180) I noticed that another project seems to have solved it by updating the syntax for scanning for devices with `bleak`: https://github.com/NaitLee/Cat-Printer/issues/22 https://github.com/NaitLee/Cat-Printer/commit/1b4402c6d2defa1da04845dbe90b2c71636cf53a

This also matches the syntax on the bleak example page https://bleak.readthedocs.io/en/latest/scanning.html