### PR TITLE
[bleak 0.18] Update bleak backend to handle updated callback type in start_notify

### DIFF
--- a/muselsl/backends.py
+++ b/muselsl/backends.py
@@ -59,7 +59,7 @@ class BleakDevice:
             bytearray(value),
             wait_for_response))
     def subscribe(self, uuid, callback=None, indication=False, wait_for_response=True):
-        def wrap(declaration_handle, data):
-            value_handle = declaration_handle + 1
+        def wrap(gatt_characteristic, data):
+            value_handle = gatt_characteristic.handle + 1
             callback(value_handle, data)
         _wait(self._client.start_notify(uuid, wrap))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ long_description = get_long_description()
 
 setup(
     name="muselsl",
-    version="2.2.1",
+    version="2.2.2",
     description="Stream and visualize EEG data from the Muse headset.",
     keywords="muse lsl eeg ble neuroscience",
     url="https://github.com/alexandrebarachant/muse-lsl/",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description_content_type='text/markdown',
     install_requires=[
         "bitstring",
-        "bleak",
+        "bleak>=0.18.0",
         "pygatt",
         "pandas",
         "scikit-learn",


### PR DESCRIPTION
This PR addresses the breaking change in bleak 0.18 of the `start_notify` function's callback returning an object instead of an int.