### PR TITLE
Expose time_func to stream() and allow option to use pylsl timestamps

### DIFF
--- a/muselsl/__init__.py
+++ b/muselsl/__init__.py
@@ -1,4 +1,4 @@
 from .stream import stream, list_muses
 from .record import record, record_direct
 from .view import view
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -102,6 +102,7 @@ class CLI:
             "-lslt",
             "--lsltime",
             default=False,
+            dest='lsl_time',
             action="store_true",
             help="Use pylsl's local_clock() for timestamps instead of Python's time.time()")
 

--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -101,6 +101,7 @@ class CLI:
         parser.add_argument(
             "-lslt",
             "--lsltime",
+            default=False,
             dest='lsl_time',
             action="store_true",
             help="Use pylsl's local_clock() for timestamps instead of Python's time.time()")
@@ -110,7 +111,8 @@ class CLI:
         from . import stream
 
         stream(args.address, args.backend, args.interface, args.name, args.ppg,
-               args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light, args.lsltime)
+               args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light,
+               args.lsl_time)
 
     def record(self):
         parser = argparse.ArgumentParser(

--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -98,13 +98,19 @@ class CLI:
             dest='disable_light',
             action='store_true',
             help='Turn off light on the Muse S headband')
+        parser.add_argument(
+            "-lslt",
+            "--lsltime",
+            default=False,
+            action="store_true",
+            help="Use pylsl's local_clock() for timestamps instead of Python's time.time()")
 
 
         args = parser.parse_args(sys.argv[2:])
         from . import stream
 
         stream(args.address, args.backend, args.interface, args.name, args.ppg,
-               args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light)
+               args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light, args.lsltime)
 
     def record(self):
         parser = argparse.ArgumentParser(

--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -101,7 +101,6 @@ class CLI:
         parser.add_argument(
             "-lslt",
             "--lsltime",
-            default=False,
             dest='lsl_time',
             action="store_true",
             help="Use pylsl's local_clock() for timestamps instead of Python's time.time()")

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -235,7 +235,7 @@ def stream(
             print("Streaming%s%s%s%s..." %
                 (eeg_string, ppg_string, acc_string, gyro_string))
 
-            while time() - muse.last_timestamp < timeout:
+            while time_func() - muse.last_timestamp < timeout:
                 try:
                     backends.sleep(1)
                 except KeyboardInterrupt:

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -1,21 +1,21 @@
 import re
 import subprocess
-from sys import platform
-from time import time
 from functools import partial
 from shutil import which
+from sys import platform
+from time import time
 
-from pylsl import StreamInfo, StreamOutlet
 import pygatt
+from pylsl import StreamInfo, StreamOutlet, local_clock
 
-from . import backends
-from . import helper
+from . import backends, helper
+from .constants import (AUTO_DISCONNECT_DELAY, LSL_ACC_CHUNK, LSL_EEG_CHUNK,
+                        LSL_GYRO_CHUNK, LSL_PPG_CHUNK, MUSE_NB_ACC_CHANNELS,
+                        MUSE_NB_EEG_CHANNELS, MUSE_NB_GYRO_CHANNELS,
+                        MUSE_NB_PPG_CHANNELS, MUSE_SAMPLING_ACC_RATE,
+                        MUSE_SAMPLING_EEG_RATE, MUSE_SAMPLING_GYRO_RATE,
+                        MUSE_SAMPLING_PPG_RATE, MUSE_SCAN_TIMEOUT)
 from .muse import Muse
-from .constants import MUSE_SCAN_TIMEOUT, AUTO_DISCONNECT_DELAY,  \
-    MUSE_NB_EEG_CHANNELS, MUSE_SAMPLING_EEG_RATE, LSL_EEG_CHUNK,  \
-    MUSE_NB_PPG_CHANNELS, MUSE_SAMPLING_PPG_RATE, LSL_PPG_CHUNK, \
-    MUSE_NB_ACC_CHANNELS, MUSE_SAMPLING_ACC_RATE, LSL_ACC_CHUNK, \
-    MUSE_NB_GYRO_CHANNELS, MUSE_SAMPLING_GYRO_RATE, LSL_GYRO_CHUNK
 
 
 def _print_muse_list(muses):
@@ -133,6 +133,7 @@ def stream(
     eeg_disabled=False,
     preset=None,
     disable_light=False,
+    lsl_time=False,
     timeout=AUTO_DISCONNECT_DELAY,
 ):
     # If no data types are enabled, we warn the user and return immediately.
@@ -215,8 +216,10 @@ def stream(
         push_acc = partial(push, outlet=acc_outlet) if acc_enabled else None
         push_gyro = partial(push, outlet=gyro_outlet) if gyro_enabled else None
 
+        time_func = local_clock if lsl_time else time
+
         muse = Muse(address=address, callback_eeg=push_eeg, callback_ppg=push_ppg, callback_acc=push_acc, callback_gyro=push_gyro,
-                    backend=backend, interface=interface, name=name, preset=preset, disable_light=disable_light)
+                    backend=backend, interface=interface, name=name, preset=preset, disable_light=disable_light, time_func=time_func)
 
         didConnect = muse.connect()
 


### PR DESCRIPTION
Adds the --lsltime argument to `stream()` to use `pylsllocal_clock()` for timestamps instead of Python's time.time() (still the default).