### PR TITLE
Error with `logging` fixed.

### DIFF
--- a/muselsl/__main__.py
+++ b/muselsl/__main__.py
@@ -17,6 +17,7 @@ def main():
                 -n --name       Device name (e.g. Muse-41D2).
                 -b --backend    BLE backend to use. can be auto, bluemuse, gatt or bgapi.
                 -i --interface  The interface to use, 'hci0' for gatt or a com port for bgapi.
+                -t --timeout    Length of timeout before giving up on connecting to an identified device.
                 -p --ppg        Include PPG data
                 -c --acc        Include accelerometer data
                 -g --gyro       Include gyroscope data
@@ -41,6 +42,7 @@ def main():
                 -n --name       Device name (e.g. Muse-41D2).
                 -b --backend    BLE backend to use. can be auto, bluemuse, gatt or bgapi.
                 -i --interface  The interface to use, 'hci0' for gatt or a com port for bgapi.
+                -t --timeout    Length of timeout before giving up on connecting to an identified device.
         ''')
 
     parser.add_argument('command', help='Command to run.')

--- a/muselsl/backends.py
+++ b/muselsl/backends.py
@@ -32,15 +32,16 @@ class BleakBackend:
             raise bleak
         devices = _wait(bleak.BleakScanner.discover(timeout))
         return [{'name':device.name, 'address':device.address} for device in devices]
-    def connect(self, address):
-        result = BleakDevice(self, address)
+    def connect(self, address, connection_timeout=None):
+        result = BleakDevice(self, address, connection_timeout)
         result.connect()
         return result
 
 class BleakDevice:
-    def __init__(self, adapter, address):
+    def __init__(self, adapter, address, connection_timeout=None):
         self._adapter = adapter
-        self._client = bleak.BleakClient(address)
+        self._timeout = connection_timeout
+        self._client = bleak.BleakClient(address, timeout=self._timeout)
     def connect(self):
         _wait(self._client.connect())
         self._adapter.connected.add(self)

--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -63,6 +63,13 @@ class CLI:
             default=None,
             help=
             "The interface to use, 'hci0' for gatt or a com port for bgapi.")
+        parser.add_argument(
+            "-t",
+            "--timeout",
+            dest="timeout",
+            type=float,
+            default=10.0,
+            help="Length of timeout before giving up on connecting to an identified device.")
         parser.add_argument("-P",
             "--preset",
             type=int,
@@ -104,7 +111,7 @@ class CLI:
         from . import stream
 
         stream(args.address, args.backend, args.interface, args.name, args.ppg,
-               args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light)
+               args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light, args.timeout)
 
     def record(self):
         parser = argparse.ArgumentParser(
@@ -174,6 +181,13 @@ class CLI:
             help=
             "The interface to use, 'hci0' for gatt or a com port for bgapi.")
         parser.add_argument(
+            "-t",
+            "--timeout",
+            dest="timeout",
+            type=float,
+            default=10.0,
+            help="Length of timeout before giving up on connecting to an identified device.")
+        parser.add_argument(
             "-d",
             "--duration",
             dest="duration",
@@ -190,7 +204,7 @@ class CLI:
         args = parser.parse_args(sys.argv[2:])
         from . import record_direct
         record_direct(args.duration, args.address, args.filename, args.backend,
-                      args.interface, args.name)
+                      args.interface, args.name, args.timeout)
 
     def view(self):
         parser = argparse.ArgumentParser(

--- a/muselsl/muse.py
+++ b/muselsl/muse.py
@@ -31,7 +31,8 @@ class Muse():
                  time_func=time,
                  name=None,
                  preset=None,
-                 disable_light=False):
+                 disable_light=False,
+                 timeout=None):
         """Initialize
 
         callback_eeg -- callback for eeg data, function(data, timestamps)
@@ -45,6 +46,7 @@ class Muse():
         """
 
         self.address = address
+        self.timeout=timeout
         self.name = name
         self.callback_eeg = callback_eeg
         self.callback_telemetry = callback_telemetry
@@ -87,7 +89,7 @@ class Muse():
                         serial_port=self.interface)
 
                 self.adapter.start()
-                self.device = self.adapter.connect(self.address)
+                self.device = self.adapter.connect(self.address, self.timeout)
                 if(self.preset != None):
                     self.select_preset(self.preset)
 

--- a/muselsl/record.py
+++ b/muselsl/record.py
@@ -183,7 +183,8 @@ def record_direct(duration,
                   filename=None,
                   backend='auto',
                   interface=None,
-                  name=None):
+                  name=None,
+                  timeout=None):
     if backend == 'bluemuse':
         raise (NotImplementedError(
             'Direct record not supported with BlueMuse backend. Use record after starting stream instead.'
@@ -211,7 +212,7 @@ def record_direct(duration,
         eeg_samples.append(new_samples)
         timestamps.append(new_timestamps)
 
-    muse = Muse(address, save_eeg, backend=backend)
+    muse = Muse(address, save_eeg, backend=backend, timeout=timeout)
     muse.connect()
     muse.start()
 

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -133,7 +133,7 @@ def stream(
     eeg_disabled=False,
     preset=None,
     disable_light=False,
-    timeout=AUTO_DISCONNECT_DELAY,
+    timeout=None,
 ):
     # If no data types are enabled, we warn the user and return immediately.
     if eeg_disabled and not ppg_enabled and not acc_enabled and not gyro_enabled:
@@ -216,7 +216,7 @@ def stream(
         push_gyro = partial(push, outlet=gyro_outlet) if gyro_enabled else None
 
         muse = Muse(address=address, callback_eeg=push_eeg, callback_ppg=push_ppg, callback_acc=push_acc, callback_gyro=push_gyro,
-                    backend=backend, interface=interface, name=name, preset=preset, disable_light=disable_light)
+                    backend=backend, interface=interface, name=name, preset=preset, disable_light=disable_light, timeout=timeout)
 
         didConnect = muse.connect()
 
@@ -232,7 +232,7 @@ def stream(
             print("Streaming%s%s%s%s..." %
                 (eeg_string, ppg_string, acc_string, gyro_string))
 
-            while time() - muse.last_timestamp < timeout:
+            while time() - muse.last_timestamp < AUTO_DISCONNECT_DELAY:
                 try:
                     backends.sleep(1)
                 except KeyboardInterrupt:


### PR DESCRIPTION
Removed the timeout string from the `logging.info()` statement, preventing an exception. Adds previous connection timeout functionality. Fixed previous --timeout argument to use `AUTO_DISCONNECT_DELAY` as the #of seconds to wait until automatically disconnecting the device and ceasing stream, instead of the connection --timeout argument.