### PR TITLE
Remove walrus operator for Python 3.7 compatibility

### DIFF
--- a/muselsl/muse.py
+++ b/muselsl/muse.py
@@ -87,8 +87,8 @@ class Muse():
                         serial_port=self.interface)
 
                 self.adapter.start()
-                if ((device := self.adapter.connect(self.address, retries))
-                    is None):
+                device = self.adapter.connect(self.address, retries)
+                if device is None:
                     return False
                 self.device = device
 


### PR DESCRIPTION
Should address https://github.com/alexandrebarachant/muse-lsl/issues/216 and https://github.com/NeuroTechX/EEG-ExPy/issues/277