### PR TITLE
Make -l a real global log-level flag

### DIFF
--- a/muselsl/cli.py
+++ b/muselsl/cli.py
@@ -2,6 +2,18 @@
 import sys
 import argparse
 from .constants import LOG_LEVELS
+from .helper import configure_logging
+
+
+def _add_log_arg(parser):
+    parser.add_argument(
+        '-l',
+        '--log',
+        choices=LOG_LEVELS.keys(),
+        dest='log_level',
+        default='info',
+        help='Set the logging level')
+
 
 class CLI:
     def __init__(self, command):
@@ -27,17 +39,11 @@ class CLI:
             help=
             "The interface to use, 'hci0' for gatt or a com port for bgapi. WIll auto-detect if not specified"
         )
-        parser.add_argument(
-            '-l',
-            "--log", 
-            choices=LOG_LEVELS.keys(),
-            dest="log_level",
-            default='info',
-            help='Set the logging level'
-        )
+        _add_log_arg(parser)
         args = parser.parse_args(sys.argv[2:])
+        configure_logging(LOG_LEVELS[args.log_level])
         from . import list_muses
-        list_muses(args.backend, args.interface, LOG_LEVELS[args.log_level])
+        list_muses(args.backend, args.interface)
 
     def stream(self):
         parser = argparse.ArgumentParser(
@@ -120,21 +126,15 @@ class CLI:
             dest='retries',
             type=int,
             help="How many times to retry connecting to the device on a failed attempt")
-        parser.add_argument(
-            '-l',
-            "--log", 
-            choices=LOG_LEVELS.keys(),
-            dest="log_level",
-            default='info',
-            help='Set the logging level'
-        )
+        _add_log_arg(parser)
 
         args = parser.parse_args(sys.argv[2:])
+        configure_logging(LOG_LEVELS[args.log_level])
         from . import stream
 
         stream(args.address, args.backend, args.interface, args.name, args.ppg,
                args.acc, args.gyro, args.disable_eeg, args.preset, args.disable_light,
-               args.lsl_time, args.retries, LOG_LEVELS[args.log_level])
+               args.lsl_time, args.retries)
 
     def record(self):
         parser = argparse.ArgumentParser(
@@ -166,8 +166,10 @@ class CLI:
             type=str,
             default="EEG",
             help="Data type to record from. Either EEG, PPG, ACC, or GYRO.")
+        _add_log_arg(parser)
 
         args = parser.parse_args(sys.argv[2:])
+        configure_logging(LOG_LEVELS[args.log_level])
         from . import record
         record(args.duration, args.filename, args.dejitter, args.type)
 
@@ -217,7 +219,9 @@ class CLI:
             type=str,
             default=None,
             help="Name of the recording file.")
+        _add_log_arg(parser)
         args = parser.parse_args(sys.argv[2:])
+        configure_logging(LOG_LEVELS[args.log_level])
         from . import record_direct
         record_direct(args.duration, args.address, args.filename, args.backend,
                       args.interface, args.name)
@@ -269,7 +273,9 @@ class CLI:
             type=str,
             default='TkAgg',
             help="Matplotlib backend to use. Default: %(default)s")
+        _add_log_arg(parser)
         args = parser.parse_args(sys.argv[2:])
+        configure_logging(LOG_LEVELS[args.log_level])
         from . import view
         view(args.window, args.scale, args.refresh, args.figure, args.version,
              args.backend)

--- a/muselsl/helper.py
+++ b/muselsl/helper.py
@@ -1,5 +1,17 @@
+import logging
 import platform
 import warnings
+
+
+def configure_logging(level):
+    """Set the process-wide log level. Call once at the CLI entry point.
+
+    logging.basicConfig() is a no-op once a handler exists, so a later call
+    can't lower/raise the level. setLevel() always applies, so this stays
+    authoritative no matter what ran first.
+    """
+    logging.basicConfig(level=level)
+    logging.getLogger().setLevel(level)
 
 
 def warn_bluemuse_not_supported(extra_text = ''):

--- a/muselsl/muse.py
+++ b/muselsl/muse.py
@@ -41,9 +41,6 @@ class Muse():
         callback_gyro -- function(timestamp, samples)
         - samples is a list of 3 samples, where each sample is [x, y, z]
         """
-        # Logging is configured once at the CLI entry point (see cli.py); a
-        # device object must not mutate global logging state.
-
         self.address = address
         self.name = name
         self.callback_eeg = callback_eeg

--- a/muselsl/muse.py
+++ b/muselsl/muse.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from typing import List, cast
 
 import bitstring
@@ -30,8 +29,7 @@ class Muse():
                  time_func=time,
                  name=None,
                  preset=None,
-                 disable_light=False,
-                 log_level=logging.ERROR):
+                 disable_light=False):
         """Initialize
 
         callback_eeg -- callback for eeg data, function(data, timestamps)
@@ -43,7 +41,8 @@ class Muse():
         callback_gyro -- function(timestamp, samples)
         - samples is a list of 3 samples, where each sample is [x, y, z]
         """
-        logging.basicConfig(stream=sys.stdout, level=log_level)
+        # Logging is configured once at the CLI entry point (see cli.py); a
+        # device object must not mutate global logging state.
 
         self.address = address
         self.name = name

--- a/muselsl/record.py
+++ b/muselsl/record.py
@@ -1,4 +1,5 @@
 import bleak
+import logging
 import numpy as np
 import pandas as pd
 import os
@@ -12,6 +13,8 @@ from .stream import find_muse
 from . import backends
 from .muse import Muse
 from .constants import LSL_SCAN_TIMEOUT, LSL_EEG_CHUNK, LSL_PPG_CHUNK, LSL_ACC_CHUNK, LSL_GYRO_CHUNK
+
+logger = logging.getLogger(__name__)
 
 # Records a fixed duration of EEG data from an LSL stream into a CSV file
 
@@ -36,12 +39,15 @@ def record(
                                  strftime('%Y-%m-%d-%H.%M.%S', gmtime())))
 
     print("Looking for a %s stream..." % (data_source))
+    logger.debug('Resolving %s stream (chunk_length=%d, timeout=%ss)',
+                 data_source, chunk_length, LSL_SCAN_TIMEOUT)
     streams = resolve_byprop('type', data_source, timeout=LSL_SCAN_TIMEOUT)
 
     if len(streams) == 0:
         print("Can't find %s stream." % (data_source))
         return
 
+    logger.info('Found %s stream; recording to %s', data_source, filename)
     print("Started acquiring data.")
     inlet = StreamInlet(streams[0], max_chunklen=chunk_length)
     # eeg_time_correction = inlet.time_correction()
@@ -102,9 +108,12 @@ def record(
                     ch_names,
                     last_written_timestamp=last_written_timestamp,
                 )
+                logger.debug('Saved up to t=%.3f (%d chunks buffered)',
+                             timestamps[-1], len(res))
                 last_written_timestamp = timestamps[-1]
 
         except KeyboardInterrupt:
+            logger.info('Recording interrupted by user')
             break
 
     time_correction = inlet.time_correction()
@@ -213,12 +222,14 @@ def record_direct(duration,
         timestamps.append(new_timestamps)
 
     muse = Muse(address, save_eeg, backend=backend)
+    logger.debug('Connecting to Muse %s (backend=%s)', address, backend)
     if not muse.connect():
         print(f'Failed to connect to Muse: {address}', file=sys.stderr)
         return
     muse.start()
 
     t_init = time()
+    logger.info('Recording directly from %s to %s for %ss', address, filename, duration)
     print('Start recording at time t=%.3f' % t_init)
 
     last_update = t_init
@@ -230,8 +241,10 @@ def record_direct(duration,
                 # Send a keep alive every 10 secs
                 if time() - last_update > 10:
                     last_update = time()
+                    logger.debug('Sending keep-alive')
                     muse.keep_alive()
             except bleak.exc.BleakError:
+                logger.warning('BLE error; attempting to reconnect', exc_info=True)
                 print('Disconnected. Attempting to reconnect...')
                 # Do not giveup since we make a best effort to continue
                 # data collection. Assume device is out of range or another

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -4,7 +4,6 @@ from functools import partial
 from shutil import which
 from sys import platform
 from time import time
-import logging
 
 import pygatt
 from pylsl import StreamInfo, StreamOutlet, local_clock
@@ -15,7 +14,7 @@ from .constants import (AUTO_DISCONNECT_DELAY, LSL_ACC_CHUNK, LSL_EEG_CHUNK,
                         MUSE_NB_EEG_CHANNELS, MUSE_NB_GYRO_CHANNELS,
                         MUSE_NB_PPG_CHANNELS, MUSE_SAMPLING_ACC_RATE,
                         MUSE_SAMPLING_EEG_RATE, MUSE_SAMPLING_GYRO_RATE,
-                        MUSE_SAMPLING_PPG_RATE, LIST_SCAN_TIMEOUT, LOG_LEVELS,
+                        MUSE_SAMPLING_PPG_RATE, LIST_SCAN_TIMEOUT,
                         RETRY_SLEEP_TIMEOUT)
 from .muse import Muse
 
@@ -28,8 +27,7 @@ def _print_muse_list(muses):
 
 
 # Returns a list of available Muse devices.
-def list_muses(backend='auto', interface=None, log_level=logging.ERROR):
-    logging.basicConfig(level=log_level)
+def list_muses(backend='auto', interface=None):
     if backend == 'auto' and which('bluetoothctl') is not None:
         print("Backend was 'auto' and bluetoothctl was found, using to list muses...")
         return _list_muses_bluetoothctl(LIST_SCAN_TIMEOUT)
@@ -138,8 +136,7 @@ def stream(
     preset=None,
     disable_light=False,
     lsl_time=False,
-    retries=1,
-    log_level=logging.ERROR
+    retries=1
 ):
     # If no data types are enabled, we warn the user and return immediately.
     if eeg_disabled and not ppg_enabled and not acc_enabled and not gyro_enabled:
@@ -231,7 +228,7 @@ def stream(
         time_func = local_clock if lsl_time else time
 
         muse = Muse(address=address, callback_eeg=push_eeg, callback_ppg=push_ppg, callback_acc=push_acc, callback_gyro=push_gyro,
-                    backend=backend, interface=interface, name=name, preset=preset, disable_light=disable_light, time_func=time_func, log_level=log_level)
+                    backend=backend, interface=interface, name=name, preset=preset, disable_light=disable_light, time_func=time_func)
 
         didConnect = muse.connect(retries=retries)
 

--- a/muselsl/view.py
+++ b/muselsl/view.py
@@ -1,5 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def view(window=5, scale=100, refresh=0.2, figure="15x6", version=1, backend='TkAgg'):
+    logger.info('Starting viewer v%d (window=%ss, scale=%suV, refresh=%ss, backend=%s)',
+                version, window, scale, refresh, backend)
     if version == 2:
         from . import viewer_v2
         viewer_v2.view()


### PR DESCRIPTION
`-l` never worked: `basicConfig` is a no-op once a handler exists, so whatever ran first (the scan, at `ERROR`) won the level and later calls were ignored. Debug logs vanished.

- `configure_logging()` (helper): `basicConfig` + `setLevel` — `setLevel` always wins, so it's authoritative regardless of order.
- Called once per command at the CLI entry point. Single source of truth.
- Ripped `log_level` params out of `Muse`/`stream`/`list_muses` (device objects no longer mutate global logging) + dead imports.
- `-l` now on all 5 commands (was 2); arg block deduped into one helper.
- Added standard logs to `record`/`record_direct`/`view` so the flag does something.

skipped: migrating existing `print()` status lines to logging (would change default output). add when wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)