### PR TITLE
Fix Muse S Athena PPG access by aliasing --ppg to optics

### DIFF
--- a/muselsl/athena.py
+++ b/muselsl/athena.py
@@ -312,7 +312,7 @@ class Athena:
                 MUSE_ATHENA_SAMPLING_GYRO_RATE, LSL_ATHENA_GYRO_CHUNK, 'dps',
             ),
             StreamDescriptor(
-                'OPTICS', 'OPTICS', MUSE_ATHENA_NB_OPTICS_CHANNELS, OPTICS_CHANNEL_NAMES,
+                'OPTICS', 'PPG', MUSE_ATHENA_NB_OPTICS_CHANNELS, OPTICS_CHANNEL_NAMES,
                 MUSE_ATHENA_SAMPLING_OPTICS_RATE, LSL_ATHENA_OPTICS_CHUNK, 'a.u.',
             ),
         ]

--- a/muselsl/lsl_outlet.py
+++ b/muselsl/lsl_outlet.py
@@ -7,7 +7,7 @@ _CHANNEL_TYPE = {
     'PPG': 'PPG',
     'ACC': 'accelerometer',
     'GYRO': 'gyroscope',
-    'OPTICS': 'optics',
+    'OPTICS': 'PPG',
 }
 
 

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -137,7 +137,7 @@ def _descriptor_enabled(name, eeg_disabled, ppg_enabled, acc_enabled, gyro_enabl
     if name == 'GYRO':
         return gyro_enabled
     if name == 'OPTICS':
-        return optics_enabled
+        return ppg_enabled or optics_enabled
     return False
 
 

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -14,6 +14,7 @@ from muselsl.constants import (
     MUSE_SAMPLING_PPG_RATE,
 )
 from muselsl.muse import Muse
+from muselsl.stream import _descriptor_enabled
 
 
 def _by_name(descriptors):
@@ -50,5 +51,16 @@ def test_athena_stream_descriptors():
     desc = _by_name(Athena('addr').stream_descriptors())
     assert desc['EEG'].n_channels == 4
     assert desc['EEG'].channel_names == ('TP9', 'AF7', 'AF8', 'TP10')
-    assert 'PPG' not in desc
-    assert desc['OPTICS'].n_channels == 16
+    # Athena PPG is delivered through the optics sensor; it is advertised as a PPG stream.
+    optics = desc['OPTICS']
+    assert optics.n_channels == 16
+    assert optics.stype == 'PPG'
+
+
+def test_ppg_flag_enables_athena_optics():
+    # --ppg should enable the Athena optics/PPG stream.
+    assert _descriptor_enabled('OPTICS', False, True, False, False, False)
+    # --optics still works.
+    assert _descriptor_enabled('OPTICS', False, False, False, False, True)
+    # Disabled when neither flag is set.
+    assert not _descriptor_enabled('OPTICS', False, False, False, False, False)


### PR DESCRIPTION
Closes #223 (or addresses the Athena PPG part).

Muse S Athena delivers PPG data through the optics sensor. Before this change, `muselsl stream --ppg` only enabled the legacy Muse PPG descriptor, so Athena users got no PPG LSL stream.

Changes:
- Treat `--ppg` as an alias for `--optics` on Athena.
- Advertise the Athena optics stream as LSL type `PPG`, so `muselsl record --type PPG` resolves it.
- Add regression tests covering the alias and the PPG stream type.

Tests pass: `python -m pytest tests/ -q` → 29 passed, 3 skipped.