### PR TITLE
Remove Linux pylsl 1.10.5 pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,6 @@ Lab Streaming Layer or LSL is a system designed to unify the collection of time 
 
 - This seems to be due to a OS-level Bluetooth crash. Try turning your computer's bluetooth off and on again
 
-5.  `'RuntimeError: could not create stream outlet'` (Linux)
-
-- This appears to be due to Linux-specific issues with the newest version of pylsl. Ensure that you have pylsl 1.10.5 installed in the environment in which you are trying to run Muse LSL
-- If this is preceded by `Could not instantiate IPv4 stack: getrandom`, it could be [this issue](https://github.com/boostorg/uuid/issues/91) which can be resolved by building `liblsl` with `-DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX` (e.g. by editing `standalone_compilation_linux.sh`)
-
 ## Citing muse-lsl
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,11 @@ setup(
         "numpy",
         "seaborn",
         "pexpect",
-        # Evaluated at install time via environment markers (not build time),
-        # so the correct pin ships in the universal wheel for every platform.
-        # Linux needs 1.10.5 (see "could not create stream outlet" in the
-        # README's Common Issues); other platforms need >=1.16 for a
-        # universal2/arm64 liblsl on Apple Silicon (see issue #203).
-        'pylsl==1.10.5; sys_platform == "linux"',
-        'pylsl>=1.16; sys_platform != "linux"',
+        # >=1.16 is needed for a universal2/arm64 liblsl on Apple Silicon
+        # (see issue #203). The old Linux pin to 1.10.5 is being removed; CI
+        # will tell us if the original "could not create stream outlet" issue
+        # resurfaces (see issue #235).
+        'pylsl>=1.16',
     ],
     extras_require={"Viewer V2": ["mne", "vispy"]},
     classifiers=[

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from muselsl.athena import Athena
 from muselsl.constants import (
     LSL_ACC_CHUNK,
@@ -13,6 +15,7 @@ from muselsl.constants import (
     MUSE_SAMPLING_GYRO_RATE,
     MUSE_SAMPLING_PPG_RATE,
 )
+from muselsl.lsl_outlet import build_outlet
 from muselsl.muse import Muse
 from muselsl.stream import _descriptor_enabled
 
@@ -64,3 +67,10 @@ def test_ppg_flag_enables_athena_optics():
     assert _descriptor_enabled('OPTICS', False, False, False, False, True)
     # Disabled when neither flag is set.
     assert not _descriptor_enabled('OPTICS', False, False, False, False, False)
+
+
+@pytest.mark.parametrize("descriptor", Muse('addr').stream_descriptors() + Athena('addr').stream_descriptors())
+def test_build_outlet_smoke(descriptor):
+    """Creating a StreamOutlet must not raise; guards against liblsl/pylsl packaging regressions."""
+    outlet = build_outlet(descriptor, '00:00:00:00:00:00')
+    assert outlet.get_info().type() == descriptor.stype


### PR DESCRIPTION
Closes #235.

Drops the Linux-specific pin to `pylsl==1.10.5` (released 2016) and requires `pylsl>=1.16` on all platforms. The original outlet-creation issue (#72) was reportedly caused by a manylinux/boost packaging conflict with the embedded `liblsl.so` that upstream has since resolved.

A parametrized `StreamOutlet` smoke test is added so CI will catch any regression of the `RuntimeError: could not create stream outlet` bug on Linux.

Relates to #72, #77, #136.